### PR TITLE
Fix calibration player assignment

### DIFF
--- a/app/src/main/java/com/robocrops/mathgalaga/GameView.kt
+++ b/app/src/main/java/com/robocrops/mathgalaga/GameView.kt
@@ -173,7 +173,6 @@ class GameView(context: Context) : SurfaceView(context), SurfaceHolder.Callback,
 
     fun startCalibration(onDetected: (deviceId: Int, player: Int, isFire: Boolean) -> Unit) {
         onCalibrationDetected = onDetected
-        calibratingPlayer = 0 // Start with player 1
         detectedDevices.clear() // Clear for new calibration
     }
 

--- a/app/src/main/java/com/robocrops/mathgalaga/controller.kt
+++ b/app/src/main/java/com/robocrops/mathgalaga/controller.kt
@@ -489,9 +489,11 @@ class CalibrationState(controller: GameController) : BaseState(controller) {
     }
 
     private fun setupCalibration() {
-        controller.view.startCalibration { deviceId, player, isFire ->
-            controller.view.playerJoystickMap[deviceId] = player
-            Log.d("MathGalaga", "Calibrated device $deviceId for player $player (isFire: $isFire)")
+        val player = if (currentStep == 0 || currentStep == 2) 0 else 1
+        controller.view.setCalibratingPlayer(player)
+        controller.view.startCalibration { deviceId, calibratedPlayer, isFire ->
+            controller.view.playerJoystickMap[deviceId] = calibratedPlayer
+            Log.d("MathGalaga", "Calibrated device $deviceId for player $calibratedPlayer (isFire: $isFire)")
             startPause()
         }
     }


### PR DESCRIPTION
## Summary
- ensure calibration step uses the current player

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68756c732ff4832a9b495bf40c46982d