### PR TITLE
Fix spurious key events

### DIFF
--- a/app/src/main/java/com/robocrops/mathgalaga/MainActivity.kt
+++ b/app/src/main/java/com/robocrops/mathgalaga/MainActivity.kt
@@ -37,8 +37,12 @@ class MainActivity : AppCompatActivity() {
     }
 
     override fun dispatchKeyEvent(event: KeyEvent): Boolean {
-        if (gameView.onKeyDown(event.keyCode, event)) return true
-        if (gameView.onKeyUp(event.keyCode, event)) return true
+        // Only forward key events that match the current action. This prevents
+        // spurious "button down" events when releasing keys.
+        when (event.action) {
+            KeyEvent.ACTION_DOWN -> if (gameView.onKeyDown(event.keyCode, event)) return true
+            KeyEvent.ACTION_UP -> if (gameView.onKeyUp(event.keyCode, event)) return true
+        }
         return super.dispatchKeyEvent(event)
     }
 


### PR DESCRIPTION
## Summary
- prevent duplicate button down events by checking `KeyEvent` action in `dispatchKeyEvent`

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687579949790832ab5b57c96cf5be914