### PR TITLE
Wrap performance logs with debug check

### DIFF
--- a/app/src/main/java/com/robocrops/mathgalaga/GameView.kt
+++ b/app/src/main/java/com/robocrops/mathgalaga/GameView.kt
@@ -14,6 +14,7 @@ import android.view.SurfaceView
 import android.util.Log
 import android.view.Choreographer
 import android.os.Handler
+import com.robocrops.mathgalaga.BuildConfig
 
 /**
  * The main view for MathGalaga.
@@ -89,12 +90,16 @@ class GameView(context: Context) : SurfaceView(context), SurfaceHolder.Callback,
                         val startUpdate = System.nanoTime()
                         controller.update(deltaMs)
                         val updateTime = (System.nanoTime() - startUpdate) / 1_000_000.0
-                        Log.d("Perf", "Update: $updateTime ms")
+                        if (BuildConfig.DEBUG) {
+                            Log.d("Perf", "Update: $updateTime ms")
+                        }
 
                         val startDraw = System.nanoTime()
                         controller.draw(canvas)
                         val drawTime = (System.nanoTime() - startDraw) / 1_000_000.0
-                        Log.d("Perf", "Draw: $drawTime ms")
+                        if (BuildConfig.DEBUG) {
+                            Log.d("Perf", "Draw: $drawTime ms")
+                        }
                     }
                 } finally {
                     holder.unlockCanvasAndPost(canvas)


### PR DESCRIPTION
## Summary
- gate performance `Log.d` calls in `GameView` behind `BuildConfig.DEBUG`

## Testing
- `./gradlew test --no-daemon --console=plain` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68757c85ddb4832a96844aa72e012b4e