### PR TITLE
Enable independent fire button calibration

### DIFF
--- a/app/src/main/java/com/robocrops/mathgalaga/GameView.kt
+++ b/app/src/main/java/com/robocrops/mathgalaga/GameView.kt
@@ -40,6 +40,7 @@ class GameView(context: Context) : SurfaceView(context), SurfaceHolder.Callback,
     private val fireButtonWasPressed = BooleanArray(2)
 
     val playerJoystickMap = mutableMapOf<Int, Int>() // deviceId to playerIndex (0 or 1)
+    val playerFireButtonMap = mutableMapOf<Int, Int>() // deviceId to playerIndex for firing
 
     // Calibration mode
     var calibratingPlayer: Int = -1
@@ -135,7 +136,7 @@ class GameView(context: Context) : SurfaceView(context), SurfaceHolder.Callback,
             detectedDevices.add(deviceId)
             return true
         }
-        val player = playerJoystickMap[deviceId] ?: return super.onKeyDown(keyCode, event)
+        val player = playerFireButtonMap[deviceId] ?: playerJoystickMap[deviceId] ?: return super.onKeyDown(keyCode, event)
         if (keyCode == KeyEvent.KEYCODE_BUTTON_11) { // 198
             firePressed[player] = true
             Log.d("MathGalaga", "Joystick button DOWN detected for player $player! (keyCode $keyCode, source: ${event.source})")
@@ -145,7 +146,7 @@ class GameView(context: Context) : SurfaceView(context), SurfaceHolder.Callback,
     }
 
     override fun onKeyUp(keyCode: Int, event: KeyEvent): Boolean {
-        val player = playerJoystickMap[event.deviceId] ?: return super.onKeyUp(keyCode, event)
+        val player = playerFireButtonMap[event.deviceId] ?: playerJoystickMap[event.deviceId] ?: return super.onKeyUp(keyCode, event)
         if (keyCode == KeyEvent.KEYCODE_BUTTON_11) { // 198
             firePressed[player] = false
             Log.d("MathGalaga", "Joystick button UP detected for player $player! (keyCode $keyCode, source: ${event.source})")
@@ -290,6 +291,7 @@ class GameView(context: Context) : SurfaceView(context), SurfaceHolder.Callback,
 
     override fun onInputDeviceRemoved(deviceId: Int) {
         playerJoystickMap.remove(deviceId)
+        playerFireButtonMap.remove(deviceId)
     }
 
     override fun onInputDeviceChanged(deviceId: Int) {

--- a/app/src/main/java/com/robocrops/mathgalaga/controller.kt
+++ b/app/src/main/java/com/robocrops/mathgalaga/controller.kt
@@ -492,7 +492,11 @@ class CalibrationState(controller: GameController) : BaseState(controller) {
         val player = if (currentStep == 0 || currentStep == 2) 0 else 1
         controller.view.setCalibratingPlayer(player)
         controller.view.startCalibration { deviceId, calibratedPlayer, isFire ->
-            controller.view.playerJoystickMap[deviceId] = calibratedPlayer
+            if (isFire) {
+                controller.view.playerFireButtonMap[deviceId] = calibratedPlayer
+            } else {
+                controller.view.playerJoystickMap[deviceId] = calibratedPlayer
+            }
             Log.d("MathGalaga", "Calibrated device $deviceId for player $calibratedPlayer (isFire: $isFire)")
             startPause()
         }


### PR DESCRIPTION
## Summary
- add playerFireButtonMap for separate fire calibration
- record fire devices in CalibrationState
- check fire button map in input callbacks
- clean up on device removal

## Testing
- `./gradlew tasks --no-daemon`
- `./gradlew test --no-daemon` *(fails: SDK location not found)*
- `sh gradlew :app:compileDebugKotlin --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68758093f44c832a8a0df7fa13592466